### PR TITLE
Исправление отрисовки, расположения дверей

### DIFF
--- a/src/internal/model/world/level.go
+++ b/src/internal/model/world/level.go
@@ -104,10 +104,10 @@ func (l *Level) generateNineRooms(sizeMap primitives.Size2D[uint]) error {
 
 			cellXStart := x*int(sectionSize.Width) + MinRoomPadding
 			cellYStart := y*int(sectionSize.Height) + MinRoomPadding
-			cellXEnd := (x+1)*int(sectionSize.Width) - MinRoomPadding
-			cellYEnd := (y+1)*int(sectionSize.Height) - MinRoomPadding
+			cellXEnd := (x + 1) * int(sectionSize.Width)
+			cellYEnd := (y + 1) * int(sectionSize.Height)
 
-			maxRoomWidth := cellXEnd - cellXStart
+			maxRoomWidth := cellXEnd - cellXStart //
 			maxRoomHeight := cellYEnd - cellYStart
 
 			if maxRoomWidth < RoomMinWidth || maxRoomHeight < RoomMinHeight {
@@ -148,11 +148,8 @@ func calculateRoomSectionSize(sizeMap primitives.Size2D[uint]) (primitives.Size2
 		return primitives.Size2D[uint]{}, errors.New("game map size is too big")
 	}
 
-	totalPaddingWidth := uint(MinRoomPadding * 2)
-	totalPaddingHeight := uint(MinRoomPadding * 2)
-
-	availableWidth := sizeMap.Width - totalPaddingWidth
-	availableHeight := sizeMap.Height - totalPaddingHeight
+	availableWidth := sizeMap.Width
+	availableHeight := sizeMap.Height
 
 	sectionSize := primitives.Size2D[uint]{
 		Width:  availableWidth / numberXYSections,
@@ -372,19 +369,33 @@ func getDoorRightWall(room Room, random utils.RandomSource) primitives.Point2D[i
 	const wall = 1
 	doorYFrom := room.Shape.Point.Y + wall
 	doorYTo := room.Shape.Point.Y + int(room.Shape.Size.Height) - wall
-	return primitives.Point2D[int]{X: room.Shape.Point.X + int(room.Shape.Size.Width), Y: random.Intn(doorYTo-doorYFrom) + doorYFrom}
+	return primitives.Point2D[int]{X: room.Shape.Point.X + int(room.Shape.Size.Width) - 1, Y: random.Intn(doorYTo-doorYFrom) + doorYFrom}
 }
 
 func getDoorTopWall(room Room, random utils.RandomSource) primitives.Point2D[int] {
 	const wall = 1
 	doorXFrom := room.Shape.Point.X + wall
-	doorXTo := room.Shape.Point.X + int(room.Shape.Size.Width) - wall
-	return primitives.Point2D[int]{X: random.Intn(doorXTo-doorXFrom) + doorXFrom, Y: room.Shape.Point.Y}
+	doorXTo := room.Shape.Point.X + int(room.Shape.Size.Width) - wall - 1
+	insideRoomWidth := doorXTo - doorXFrom
+	var doorX int
+	if insideRoomWidth == 0 {
+		doorX = doorXFrom
+	} else {
+		doorX = random.Intn(doorXTo-doorXFrom) + doorXFrom
+	}
+	return primitives.Point2D[int]{X: doorX, Y: room.Shape.Point.Y}
 }
 
 func getDoorDownWall(room Room, random utils.RandomSource) primitives.Point2D[int] {
 	const wall = 1
 	doorXFrom := room.Shape.Point.X + wall
-	doorXTo := room.Shape.Point.X + int(room.Shape.Size.Width)
-	return primitives.Point2D[int]{X: random.Intn(doorXTo-doorXFrom) + doorXFrom, Y: room.Shape.Point.Y + int(room.Shape.Size.Height)}
+	doorXTo := room.Shape.Point.X + int(room.Shape.Size.Width) - wall - 1
+	insideRoomWidth := doorXTo - doorXFrom
+	var doorX int
+	if insideRoomWidth == 0 {
+		doorX = doorXFrom
+	} else {
+		doorX = random.Intn(doorXTo-doorXFrom) + doorXFrom
+	}
+	return primitives.Point2D[int]{X: doorX, Y: room.Shape.Point.Y + int(room.Shape.Size.Height) - 1}
 }

--- a/src/internal/model/world/level.go
+++ b/src/internal/model/world/level.go
@@ -155,8 +155,8 @@ func calculateRoomSectionSize(sizeMap primitives.Size2D[uint]) (primitives.Size2
 		Width:  availableWidth / numberXYSections,
 		Height: availableHeight / numberXYSections,
 	}
-
-	if sectionSize.Width < RoomMinWidth || sectionSize.Height < RoomMinHeight {
+	const areaForPassage = 1
+	if sectionSize.Width < RoomMinWidth+areaForPassage || sectionSize.Height < RoomMinHeight+areaForPassage {
 		return primitives.Size2D[uint]{}, errors.New("game map size is too small")
 	}
 

--- a/src/internal/model/world/level.go
+++ b/src/internal/model/world/level.go
@@ -107,7 +107,7 @@ func (l *Level) generateNineRooms(sizeMap primitives.Size2D[uint]) error {
 			cellXEnd := (x + 1) * int(sectionSize.Width)
 			cellYEnd := (y + 1) * int(sectionSize.Height)
 
-			maxRoomWidth := cellXEnd - cellXStart //
+			maxRoomWidth := cellXEnd - cellXStart
 			maxRoomHeight := cellYEnd - cellYStart
 
 			if maxRoomWidth < RoomMinWidth || maxRoomHeight < RoomMinHeight {

--- a/src/internal/model/world/level_test.go
+++ b/src/internal/model/world/level_test.go
@@ -618,7 +618,7 @@ func TestLevel_AddRandomEdges_Deterministic(t *testing.T) {
 
 func TestLevel_GetStartPositionForPlayer(t *testing.T) {
 	t.Run("Rooms_exist", func(t *testing.T) {
-		wantPlayerStartPoint := primitives.Point2D[int]{X: 47, Y: 28}
+		wantPlayerStartPoint := primitives.Point2D[int]{X: 38, Y: 26}
 
 		source := rand.New(rand.NewSource(randomSeedTest))
 		level := NewLevel(source)

--- a/src/internal/model/world/level_test.go
+++ b/src/internal/model/world/level_test.go
@@ -75,70 +75,70 @@ func TestLevel_GenerateNineRooms_Deterministic(t *testing.T) {
 		{
 			Type: RoomTypeOrdinary,
 			Shape: primitives.Box{
-				Point: primitives.Point2D[int]{X: 4, Y: 1},
-				Size:  primitives.Size2D[uint]{Width: 21, Height: 7},
-			},
-		},
-		{
-			Type: RoomTypeOrdinary,
-			Shape: primitives.Box{
-				Point: primitives.Point2D[int]{X: 35, Y: 3},
-				Size:  primitives.Size2D[uint]{Width: 6, Height: 5},
-			},
-		},
-		{
-			Type: RoomTypeOrdinary,
-			Shape: primitives.Box{
-				Point: primitives.Point2D[int]{X: 67, Y: 3},
-				Size:  primitives.Size2D[uint]{Width: 4, Height: 3},
-			},
-		},
-		{
-			Type: RoomTypeOrdinary,
-			Shape: primitives.Box{
-				Point: primitives.Point2D[int]{X: 12, Y: 10},
-				Size:  primitives.Size2D[uint]{Width: 12, Height: 7},
-			},
-		},
-		{
-			Type: RoomTypeOrdinary,
-			Shape: primitives.Box{
-				Point: primitives.Point2D[int]{X: 39, Y: 11},
-				Size:  primitives.Size2D[uint]{Width: 14, Height: 5},
-			},
-		},
-		{
-			Type: RoomTypeFinish,
-			Shape: primitives.Box{
-				Point: primitives.Point2D[int]{X: 61, Y: 11},
-				Size:  primitives.Size2D[uint]{Width: 7, Height: 5},
-			},
-		},
-		{
-			Type: RoomTypeOrdinary,
-			Shape: primitives.Box{
-				Point: primitives.Point2D[int]{X: 2, Y: 19},
-				Size:  primitives.Size2D[uint]{Width: 26, Height: 7},
-			},
-		},
-		{
-			Type: RoomTypeStart,
-			Shape: primitives.Box{
-				Point: primitives.Point2D[int]{X: 37, Y: 23},
+				Point: primitives.Point2D[int]{X: 8, Y: 3},
 				Size:  primitives.Size2D[uint]{Width: 10, Height: 3},
 			},
 		},
 		{
 			Type: RoomTypeOrdinary,
 			Shape: primitives.Box{
-				Point: primitives.Point2D[int]{X: 66, Y: 21},
-				Size:  primitives.Size2D[uint]{Width: 13, Height: 4},
+				Point: primitives.Point2D[int]{X: 44, Y: 1},
+				Size:  primitives.Size2D[uint]{Width: 16, Height: 8},
+			},
+		},
+		{
+			Type: RoomTypeOrdinary,
+			Shape: primitives.Box{
+				Point: primitives.Point2D[int]{X: 61, Y: 3},
+				Size:  primitives.Size2D[uint]{Width: 26, Height: 6},
+			},
+		},
+		{
+			Type: RoomTypeOrdinary,
+			Shape: primitives.Box{
+				Point: primitives.Point2D[int]{X: 1, Y: 11},
+				Size:  primitives.Size2D[uint]{Width: 9, Height: 8},
+			},
+		},
+		{
+			Type: RoomTypeOrdinary,
+			Shape: primitives.Box{
+				Point: primitives.Point2D[int]{X: 40, Y: 13},
+				Size:  primitives.Size2D[uint]{Width: 20, Height: 3},
+			},
+		},
+		{
+			Type: RoomTypeFinish,
+			Shape: primitives.Box{
+				Point: primitives.Point2D[int]{X: 63, Y: 14},
+				Size:  primitives.Size2D[uint]{Width: 5, Height: 3},
+			},
+		},
+		{
+			Type: RoomTypeOrdinary,
+			Shape: primitives.Box{
+				Point: primitives.Point2D[int]{X: 10, Y: 24},
+				Size:  primitives.Size2D[uint]{Width: 7, Height: 3},
+			},
+		},
+		{
+			Type: RoomTypeStart,
+			Shape: primitives.Box{
+				Point: primitives.Point2D[int]{X: 33, Y: 23},
+				Size:  primitives.Size2D[uint]{Width: 17, Height: 7},
+			},
+		},
+		{
+			Type: RoomTypeOrdinary,
+			Shape: primitives.Box{
+				Point: primitives.Point2D[int]{X: 66, Y: 25},
+				Size:  primitives.Size2D[uint]{Width: 11, Height: 5},
 			},
 		},
 	}
 
 	wantFinishPortal := primitives.Box{
-		Point: primitives.Point2D[int]{X: 62, Y: 14},
+		Point: primitives.Point2D[int]{X: 64, Y: 15},
 		Size:  primitives.Size2D[uint]{Width: 1, Height: 1},
 	}
 	if level.FinishPortal != wantFinishPortal {
@@ -177,78 +177,93 @@ func TestLevel_GeneratePassages_Deterministic(t *testing.T) {
 			name: "Generate Passages with deterministic rooms",
 			wantPassages: []Passage{
 				{
-					DoorOne: primitives.Point2D[int]{X: 25, Y: 3},
-					DoorTwo: primitives.Point2D[int]{X: 35, Y: 4},
+					DoorOne: primitives.Point2D[int]{X: 17, Y: 4},
+					DoorTwo: primitives.Point2D[int]{X: 44, Y: 2},
 					Way: []primitives.Point2D[int]{
-						{X: 26, Y: 3}, {X: 27, Y: 3}, {X: 28, Y: 3}, {X: 29, Y: 3}, {X: 30, Y: 3},
-						{X: 30, Y: 4}, {X: 31, Y: 4}, {X: 32, Y: 4}, {X: 33, Y: 4}, {X: 34, Y: 4},
+						{X: 18, Y: 4}, {X: 19, Y: 4}, {X: 20, Y: 4}, {X: 21, Y: 4}, {X: 22, Y: 4},
+						{X: 23, Y: 4}, {X: 24, Y: 4}, {X: 25, Y: 4}, {X: 26, Y: 4}, {X: 27, Y: 4},
+						{X: 28, Y: 4}, {X: 29, Y: 4}, {X: 30, Y: 4}, {X: 30, Y: 3}, {X: 30, Y: 2},
+						{X: 31, Y: 2}, {X: 32, Y: 2}, {X: 33, Y: 2}, {X: 34, Y: 2}, {X: 35, Y: 2},
+						{X: 36, Y: 2}, {X: 37, Y: 2}, {X: 38, Y: 2}, {X: 39, Y: 2}, {X: 40, Y: 2},
+						{X: 41, Y: 2}, {X: 42, Y: 2}, {X: 43, Y: 2},
 					},
 				},
 				{
-					DoorOne: primitives.Point2D[int]{X: 9, Y: 8},
-					DoorTwo: primitives.Point2D[int]{X: 21, Y: 10},
+					DoorOne: primitives.Point2D[int]{X: 13, Y: 5},
+					DoorTwo: primitives.Point2D[int]{X: 2, Y: 11},
 					Way: []primitives.Point2D[int]{
-						{X: 9, Y: 9}, {X: 10, Y: 9}, {X: 11, Y: 9}, {X: 12, Y: 9},
-						{X: 13, Y: 9}, {X: 14, Y: 9}, {X: 15, Y: 9}, {X: 16, Y: 9},
-						{X: 17, Y: 9}, {X: 18, Y: 9}, {X: 19, Y: 9}, {X: 20, Y: 9}, {X: 21, Y: 9},
+						{X: 13, Y: 6}, {X: 12, Y: 6}, {X: 11, Y: 6}, {X: 10, Y: 6}, {X: 9, Y: 6},
+						{X: 8, Y: 6}, {X: 7, Y: 6}, {X: 6, Y: 6}, {X: 5, Y: 6}, {X: 4, Y: 6},
+						{X: 3, Y: 6}, {X: 2, Y: 6}, {X: 2, Y: 7}, {X: 2, Y: 8}, {X: 2, Y: 9},
+						{X: 2, Y: 10},
 					},
 				},
 				{
-					DoorOne: primitives.Point2D[int]{X: 24, Y: 12},
-					DoorTwo: primitives.Point2D[int]{X: 39, Y: 12},
+					DoorOne: primitives.Point2D[int]{X: 9, Y: 14},
+					DoorTwo: primitives.Point2D[int]{X: 40, Y: 14},
 					Way: []primitives.Point2D[int]{
-						{X: 25, Y: 12}, {X: 26, Y: 12}, {X: 27, Y: 12}, {X: 28, Y: 12}, {X: 29, Y: 12},
-						{X: 30, Y: 12}, {X: 31, Y: 12}, {X: 32, Y: 12}, {X: 33, Y: 12}, {X: 34, Y: 12},
-						{X: 35, Y: 12}, {X: 36, Y: 12}, {X: 37, Y: 12}, {X: 38, Y: 12},
+						{X: 10, Y: 14}, {X: 11, Y: 14}, {X: 12, Y: 14}, {X: 13, Y: 14}, {X: 14, Y: 14},
+						{X: 15, Y: 14}, {X: 16, Y: 14}, {X: 17, Y: 14}, {X: 18, Y: 14}, {X: 19, Y: 14},
+						{X: 20, Y: 14}, {X: 21, Y: 14}, {X: 22, Y: 14}, {X: 23, Y: 14}, {X: 24, Y: 14},
+						{X: 25, Y: 14}, {X: 26, Y: 14}, {X: 27, Y: 14}, {X: 28, Y: 14}, {X: 29, Y: 14},
+						{X: 30, Y: 14}, {X: 31, Y: 14}, {X: 32, Y: 14}, {X: 33, Y: 14}, {X: 34, Y: 14},
+						{X: 35, Y: 14}, {X: 36, Y: 14}, {X: 37, Y: 14}, {X: 38, Y: 14}, {X: 39, Y: 14},
 					},
 				},
 				{
-					DoorOne: primitives.Point2D[int]{X: 13, Y: 17},
-					DoorTwo: primitives.Point2D[int]{X: 11, Y: 19},
+					DoorOne: primitives.Point2D[int]{X: 4, Y: 18},
+					DoorTwo: primitives.Point2D[int]{X: 11, Y: 24},
 					Way: []primitives.Point2D[int]{
-						{X: 13, Y: 18}, {X: 12, Y: 18}, {X: 11, Y: 18},
+						{X: 4, Y: 19}, {X: 5, Y: 19}, {X: 6, Y: 19}, {X: 7, Y: 19}, {X: 8, Y: 19},
+						{X: 9, Y: 19}, {X: 10, Y: 19}, {X: 11, Y: 19}, {X: 11, Y: 20}, {X: 11, Y: 21},
+						{X: 11, Y: 22}, {X: 11, Y: 23},
 					},
 				},
 				{
-					DoorOne: primitives.Point2D[int]{X: 28, Y: 20},
-					DoorTwo: primitives.Point2D[int]{X: 37, Y: 24},
+					DoorOne: primitives.Point2D[int]{X: 16, Y: 25},
+					DoorTwo: primitives.Point2D[int]{X: 33, Y: 25},
 					Way: []primitives.Point2D[int]{
-						{X: 29, Y: 20}, {X: 30, Y: 20}, {X: 31, Y: 20}, {X: 31, Y: 21},
-						{X: 31, Y: 22}, {X: 31, Y: 23}, {X: 31, Y: 24}, {X: 32, Y: 24},
-						{X: 33, Y: 24}, {X: 34, Y: 24}, {X: 35, Y: 24}, {X: 36, Y: 24},
+						{X: 17, Y: 25}, {X: 18, Y: 25}, {X: 19, Y: 25}, {X: 20, Y: 25}, {X: 21, Y: 25},
+						{X: 22, Y: 25}, {X: 23, Y: 25}, {X: 24, Y: 25}, {X: 25, Y: 25}, {X: 26, Y: 25},
+						{X: 27, Y: 25}, {X: 28, Y: 25}, {X: 29, Y: 25}, {X: 30, Y: 25}, {X: 31, Y: 25},
+						{X: 32, Y: 25},
 					},
 				},
 				{
-					DoorOne: primitives.Point2D[int]{X: 47, Y: 24},
-					DoorTwo: primitives.Point2D[int]{X: 66, Y: 23},
+					DoorOne: primitives.Point2D[int]{X: 49, Y: 24},
+					DoorTwo: primitives.Point2D[int]{X: 66, Y: 26},
 					Way: []primitives.Point2D[int]{
-						{X: 48, Y: 24}, {X: 49, Y: 24}, {X: 50, Y: 24}, {X: 51, Y: 24}, {X: 52, Y: 24},
-						{X: 53, Y: 24}, {X: 54, Y: 24}, {X: 55, Y: 24}, {X: 56, Y: 24}, {X: 57, Y: 24},
-						{X: 57, Y: 23}, {X: 58, Y: 23}, {X: 59, Y: 23}, {X: 60, Y: 23}, {X: 61, Y: 23},
-						{X: 62, Y: 23}, {X: 63, Y: 23}, {X: 64, Y: 23}, {X: 65, Y: 23},
+						{X: 50, Y: 24}, {X: 50, Y: 25}, {X: 50, Y: 26}, {X: 51, Y: 26}, {X: 52, Y: 26},
+						{X: 53, Y: 26}, {X: 54, Y: 26}, {X: 55, Y: 26}, {X: 56, Y: 26}, {X: 57, Y: 26},
+						{X: 58, Y: 26}, {X: 59, Y: 26}, {X: 60, Y: 26}, {X: 61, Y: 26}, {X: 62, Y: 26},
+						{X: 63, Y: 26}, {X: 64, Y: 26}, {X: 65, Y: 26},
 					},
 				},
 				{
-					DoorOne: primitives.Point2D[int]{X: 66, Y: 16},
-					DoorTwo: primitives.Point2D[int]{X: 69, Y: 21},
+					DoorOne: primitives.Point2D[int]{X: 64, Y: 16},
+					DoorTwo: primitives.Point2D[int]{X: 72, Y: 25},
 					Way: []primitives.Point2D[int]{
-						{X: 66, Y: 17}, {X: 67, Y: 17}, {X: 68, Y: 17},
-						{X: 69, Y: 17}, {X: 69, Y: 18}, {X: 69, Y: 19}, {X: 69, Y: 20},
+						{X: 64, Y: 17}, {X: 65, Y: 17}, {X: 66, Y: 17}, {X: 67, Y: 17}, {X: 68, Y: 17},
+						{X: 69, Y: 17}, {X: 70, Y: 17}, {X: 71, Y: 17}, {X: 72, Y: 17}, {X: 72, Y: 18},
+						{X: 72, Y: 19}, {X: 72, Y: 20}, {X: 72, Y: 21}, {X: 72, Y: 22}, {X: 72, Y: 23},
+						{X: 72, Y: 24},
 					},
 				},
 				{
-					DoorOne: primitives.Point2D[int]{X: 68, Y: 6},
-					DoorTwo: primitives.Point2D[int]{X: 63, Y: 11},
+					DoorOne: primitives.Point2D[int]{X: 68, Y: 8},
+					DoorTwo: primitives.Point2D[int]{X: 64, Y: 14},
 					Way: []primitives.Point2D[int]{
-						{X: 68, Y: 7}, {X: 68, Y: 8}, {X: 68, Y: 9}, {X: 67, Y: 9},
-						{X: 66, Y: 9}, {X: 65, Y: 9}, {X: 64, Y: 9}, {X: 63, Y: 9}, {X: 63, Y: 10},
+						{X: 68, Y: 9}, {X: 68, Y: 10}, {X: 68, Y: 11}, {X: 68, Y: 12},
+						{X: 67, Y: 12}, {X: 66, Y: 12}, {X: 65, Y: 12}, {X: 64, Y: 12}, {X: 64, Y: 13},
 					},
 				},
 				{
-					DoorOne: primitives.Point2D[int]{X: 39, Y: 8},
-					DoorTwo: primitives.Point2D[int]{X: 41, Y: 11},
+					DoorOne: primitives.Point2D[int]{X: 47, Y: 8},
+					DoorTwo: primitives.Point2D[int]{X: 56, Y: 13},
 					Way: []primitives.Point2D[int]{
-						{X: 39, Y: 9}, {X: 40, Y: 9}, {X: 41, Y: 9}, {X: 41, Y: 10},
+						{X: 47, Y: 9}, {X: 47, Y: 10}, {X: 47, Y: 11}, {X: 48, Y: 11}, {X: 49, Y: 11},
+						{X: 50, Y: 11}, {X: 51, Y: 11}, {X: 52, Y: 11}, {X: 53, Y: 11}, {X: 54, Y: 11},
+						{X: 55, Y: 11}, {X: 56, Y: 11}, {X: 56, Y: 12},
 					},
 				},
 			},
@@ -281,16 +296,16 @@ func TestLevel_GeneratePassages_Deterministic(t *testing.T) {
 						i, wantPassage.DoorOne, gotPassage.DoorOne)
 				}
 				if gotPassage.DoorTwo != wantPassage.DoorTwo {
-					t.Errorf("Passage at index %d field 'DoorOne' mismatches: expected %v, got %v",
+					t.Errorf("Passage at index %d field 'DoorTwo' mismatches: expected %v, got %v",
 						i, wantPassage.DoorTwo, gotPassage.DoorTwo)
 				}
 				if len(gotPassage.Way) != len(wantPassage.Way) {
-					t.Errorf("Passage at index %d Passage slice length mismatch: expected %d, got %d", i, len(wantPassage.Way), len(gotPassage.Way))
+					t.Errorf("Passage at index %d Way slice length mismatch: expected %d, got %d", i, len(wantPassage.Way), len(gotPassage.Way))
 				} else {
 					for j, wantPoint := range wantPassage.Way {
 						gotPoint := gotPassage.Way[j]
 						if gotPoint != wantPoint {
-							t.Errorf("Passage at index %d, point in Passage at index %d mismatch: expected %+v, got %+v", i, j, wantPoint, gotPoint)
+							t.Errorf("Passage at index %d, point in Way at index %d mismatch: expected %+v, got %+v", i, j, wantPoint, gotPoint)
 						}
 					}
 				}
@@ -309,17 +324,17 @@ func TestLevel_CalculateRoomSectionSize(t *testing.T) {
 		{
 			name:    "Valid size 33x33",
 			sizeMap: primitives.Size2D[uint]{Width: 33, Height: 33},
-			want:    primitives.Size2D[uint]{Width: 10, Height: 10},
+			want:    primitives.Size2D[uint]{Width: 11, Height: 11},
 			wantErr: nil,
 		},
 		{
 			name:    "Valid size 60x45",
 			sizeMap: primitives.Size2D[uint]{Width: 60, Height: 45},
-			want:    primitives.Size2D[uint]{Width: 19, Height: 14},
+			want:    primitives.Size2D[uint]{Width: 20, Height: 15},
 			wantErr: nil,
 		},
 		{
-			name:    "Size too small for rooms",
+			name:    "SizeTooSmallForRooms",
 			sizeMap: primitives.Size2D[uint]{Width: 10, Height: 10},
 			want:    primitives.Size2D[uint]{},
 			wantErr: errors.New("game map size is too small"),
@@ -343,21 +358,21 @@ func TestLevel_CalculateRoomSectionSize(t *testing.T) {
 			wantErr: errors.New("game map size is too big"),
 		},
 		{
-			name:    "Minimum valid size 15x15",
-			sizeMap: primitives.Size2D[uint]{Width: 15, Height: 15},
+			name:    "Minimum valid size 12x12",
+			sizeMap: primitives.Size2D[uint]{Width: 12, Height: 12},
 			want:    primitives.Size2D[uint]{Width: 4, Height: 4},
 			wantErr: nil,
 		},
 		{
-			name:    "Size just below minimum - 10x10",
-			sizeMap: primitives.Size2D[uint]{Width: 10, Height: 10},
+			name:    "Size just below minimum - 11x11",
+			sizeMap: primitives.Size2D[uint]{Width: 11, Height: 11},
 			want:    primitives.Size2D[uint]{},
 			wantErr: errors.New("game map size is too small"),
 		},
 		{
 			name:    "Size with remainder - 35x34",
 			sizeMap: primitives.Size2D[uint]{Width: 35, Height: 34},
-			want:    primitives.Size2D[uint]{Width: 11, Height: 10},
+			want:    primitives.Size2D[uint]{Width: 11, Height: 11},
 			wantErr: nil,
 		},
 	}
@@ -371,14 +386,14 @@ func TestLevel_CalculateRoomSectionSize(t *testing.T) {
 					t.Errorf("Expected error to contain: %v, got: %v", tt.wantErr, err)
 				}
 			} else if tt.wantErr != nil && err == nil {
-				t.Errorf("Expected error to contain: %v, got: <nil>", tt.wantErr)
+				t.Fatalf("Expected error to contain: %v, got: <nil>", tt.wantErr)
 			} else if tt.wantErr == nil && err != nil {
-				t.Errorf("Expected: <nil>, got error: %v", err)
+				t.Fatalf("Expected: <nil>, got error: %v", err)
 			}
 
 			if tt.wantErr == nil {
 				if res != tt.want {
-					t.Errorf("Expected size (H, W): %v, got size (H, W): %v", tt.want, res)
+					t.Fatalf("Expected size %+v, got size %+v", tt.want, res)
 				}
 			}
 		})
@@ -603,8 +618,8 @@ func TestLevel_AddRandomEdges_Deterministic(t *testing.T) {
 }
 
 func TestLevel_GetStartPositionForPlayer(t *testing.T) {
-	t.Run("Rooms exist", func(t *testing.T) {
-		wantPlayerStartPoint := primitives.Point2D[int]{X: 40, Y: 24}
+	t.Run("Rooms_exist", func(t *testing.T) {
+		wantPlayerStartPoint := primitives.Point2D[int]{X: 45, Y: 28}
 
 		source := rand.New(rand.NewSource(randomSeedTest))
 		level := NewLevel(source)

--- a/src/internal/model/world/room_test.go
+++ b/src/internal/model/world/room_test.go
@@ -87,7 +87,7 @@ func TestRoom_GetRandomFreePosition(t *testing.T) {
 			wantErr:           nil,
 		},
 		{
-			name:     "Room with occupied positions",
+			name:     "RoomWithCccupiedPositions",
 			roomType: RoomTypeOrdinary,
 			roomSize: primitives.Box{Point: primitives.Point2D[int]{X: 6, Y: 3}, Size: primitives.Size2D[uint]{Height: 10, Width: 10}},
 			OccupiedPositions: map[primitives.Point2D[int]]bool{
@@ -99,7 +99,7 @@ func TestRoom_GetRandomFreePosition(t *testing.T) {
 			wantErr: nil,
 		},
 		{
-			name:     "Absence free positions in room",
+			name:     "AbsenceFreePositionsInRoom",
 			roomType: RoomTypeOrdinary,
 			roomSize: primitives.Box{Point: primitives.Point2D[int]{X: 6, Y: 3}, Size: primitives.Size2D[uint]{Height: 3, Width: 3}},
 			OccupiedPositions: map[primitives.Point2D[int]]bool{

--- a/src/internal/presentation/cli/state/game.go
+++ b/src/internal/presentation/cli/state/game.go
@@ -154,10 +154,10 @@ func isInSomeRoom(pos primitives.Point2D[int], rooms []world.Room) bool {
 }
 
 func isInRoom(pos primitives.Point2D[int], room world.Room) bool {
-	leftEndX := room.Shape.Point.X
-	rightEndX := leftEndX + int(room.Shape.Size.Width)
-	topEndY := room.Shape.Point.Y
-	downEndY := topEndY + int(room.Shape.Size.Height)
+	leftEndX := room.Shape.Point.X + 1
+	rightEndX := leftEndX + int(room.Shape.Size.Width) - 3
+	topEndY := room.Shape.Point.Y + 1
+	downEndY := topEndY + int(room.Shape.Size.Height) - 3
 
 	return (pos.X >= leftEndX && pos.X <= rightEndX) &&
 		(pos.Y >= topEndY && pos.Y <= downEndY)
@@ -284,46 +284,46 @@ func (g *Game) makeField(w, h int) [][]common.EntityType {
 
 	// Добавлено в качестве примера, потом надо будет убрать
 	g.level.Rooms[0].Enemies = []entities.Enemy{
-		{
-			Type: entities.EnemyType(entities.EnemyTypeZombie),
-			Character: &entities.Character{
-				Shape: &primitives.Box{
-					Point: primitives.Point2D[int]{X: 6, Y: 6},
-				},
-			},
-		},
-		{
-			Type: entities.EnemyType(entities.EnemyTypeVampire),
-			Character: &entities.Character{
-				Shape: &primitives.Box{
-					Point: primitives.Point2D[int]{X: 6, Y: 7},
-				},
-			},
-		},
-		{
-			Type: entities.EnemyType(entities.EnemyTypeGhost),
-			Character: &entities.Character{
-				Shape: &primitives.Box{
-					Point: primitives.Point2D[int]{X: 6, Y: 8},
-				},
-			},
-		},
-		{
-			Type: entities.EnemyType(entities.EnemyTypeOgre),
-			Character: &entities.Character{
-				Shape: &primitives.Box{
-					Point: primitives.Point2D[int]{X: 6, Y: 9},
-				},
-			},
-		},
-		{
-			Type: entities.EnemyType(entities.EnemyTypeSnakeMage),
-			Character: &entities.Character{
-				Shape: &primitives.Box{
-					Point: primitives.Point2D[int]{X: 6, Y: 10},
-				},
-			},
-		},
+		//{
+		//	Type: entities.EnemyType(entities.EnemyTypeZombie),
+		//	Character: &entities.Character{
+		//		Shape: &primitives.Box{
+		//			Point: primitives.Point2D[int]{X: 6, Y: 6},
+		//		},
+		//	},
+		//},
+		//{
+		//	Type: entities.EnemyType(entities.EnemyTypeVampire),
+		//	Character: &entities.Character{
+		//		Shape: &primitives.Box{
+		//			Point: primitives.Point2D[int]{X: 6, Y: 7},
+		//		},
+		//	},
+		//},
+		//{
+		//	Type: entities.EnemyType(entities.EnemyTypeGhost),
+		//	Character: &entities.Character{
+		//		Shape: &primitives.Box{
+		//			Point: primitives.Point2D[int]{X: 6, Y: 8},
+		//		},
+		//	},
+		//},
+		//{
+		//	Type: entities.EnemyType(entities.EnemyTypeOgre),
+		//	Character: &entities.Character{
+		//		Shape: &primitives.Box{
+		//			Point: primitives.Point2D[int]{X: 6, Y: 9},
+		//		},
+		//	},
+		//},
+		//{
+		//	Type: entities.EnemyType(entities.EnemyTypeSnakeMage),
+		//	Character: &entities.Character{
+		//		Shape: &primitives.Box{
+		//			Point: primitives.Point2D[int]{X: 6, Y: 10},
+		//		},
+		//	},
+		//},
 	}
 
 	for _, room := range g.level.Rooms {
@@ -379,14 +379,20 @@ func (g *Game) putEnemies(room world.Room, field [][]common.EntityType) {
 func (g *Game) putRoom(room world.Room, finishPortal primitives.Box, field [][]common.EntityType) {
 	width := int(room.Shape.Size.Width)
 	height := int(room.Shape.Size.Height)
-	for col := room.Shape.Point.X; col <= room.Shape.Point.X+width; col++ {
-		field[room.Shape.Point.Y][col] = common.EntityTypeWall
-		field[room.Shape.Point.Y+height][col] = common.EntityTypeWall
+
+	startX := room.Shape.Point.X
+	endX := startX + width - 1
+	startY := room.Shape.Point.Y
+	endY := startY + height - 1
+
+	for col := startX; col <= endX; col++ {
+		field[startY][col] = common.EntityTypeWall
+		field[endY][col] = common.EntityTypeWall
 	}
 
-	for row := room.Shape.Point.Y; row < room.Shape.Point.Y+height; row++ {
-		field[row][room.Shape.Point.X] = common.EntityTypeWall
-		field[row][room.Shape.Point.X+width] = common.EntityTypeWall
+	for row := startY; row <= endY; row++ {
+		field[row][startX] = common.EntityTypeWall
+		field[row][endX] = common.EntityTypeWall
 	}
 
 	field[finishPortal.Point.Y][finishPortal.Point.X] = common.EntityTypePortal

--- a/src/internal/presentation/cli/state/game.go
+++ b/src/internal/presentation/cli/state/game.go
@@ -154,6 +154,7 @@ func isInSomeRoom(pos primitives.Point2D[int], rooms []world.Room) bool {
 }
 
 func isInRoom(pos primitives.Point2D[int], room world.Room) bool {
+	// Проверка того, что персонаж находится внутри области комнаты
 	leftEndX := room.Shape.Point.X + 1
 	rightEndX := leftEndX + int(room.Shape.Size.Width) - 3
 	topEndY := room.Shape.Point.Y + 1
@@ -164,7 +165,7 @@ func isInRoom(pos primitives.Point2D[int], room world.Room) bool {
 }
 
 func checkCollisionWithRoomWall(pos primitives.Point2D[int], room world.Room) bool {
-	// Двери явлюятся частью комнаты и её стен, но через них можно ходить
+	// Двери являются частью комнаты и её стен, но через них можно ходить
 	if checkCollisionWithDoors(pos, room.Doors) {
 		return false
 	}


### PR DESCRIPTION
В общем когда я делала тест для любой задачи, заметила, что у меня минимальный размер игрового поля допустим 17х17, что мне показалось довольно большим, так ещё и минимальные комнаты делаются создаются 4x4 вместо 3х3. Причём эти комнаты 4х4 считали, что у них высота = 3 и ширина = 3:
<img width="176" height="335" alt="image" src="https://github.com/user-attachments/assets/e3cd78fb-1182-4f70-8243-dbb224ed9b35" />

Я нашла где это делается в отрисовке и, поправила, но вместе с исправлениями полетела коллизия, двери вразброс пошли. Так как всё это строилось на  неправильной картинке. Поправила и теперь 17х17 даёт уже вот такой результат:
<img width="165" height="297" alt="image" src="https://github.com/user-attachments/assets/bb3f0b66-f429-4cff-b024-36951c8ad16b" />

Ну а минимальный размер карты теперь 12х12
<img width="214" height="290" alt="image" src="https://github.com/user-attachments/assets/2cf64c8f-ba69-47a3-9afd-369e809f88a5" />

Из-за моей невнимательности ранее теперь всем тестам с seed капец, поправлю их завтра