### PR TITLE
Убрала ручки для визуального разделения food, elixir и scroll

### DIFF
--- a/src/internal/common/common.go
+++ b/src/internal/common/common.go
@@ -15,20 +15,9 @@ const (
 	EntityTypeGhost
 	EntityTypeOgre
 	EntityTypeSnakeMage
-	FoodTypePotatoes
-	FoodTypeBread
-	FoodTypeMeat
-	FoodTypeMistery
-	FoodTypeBeer
-	ElixirTypeStrength
-	ElixirTypeAgility
-	ElixirTypeDwarfism
-	ElixirTypeGiantism
-	ElixirTypeMystery
-	ScrollTypeStrength
-	ScrollTypeAgility
-	ScrollTypeUltimate
-	ScrollTypeMaxHealth
-	ScrollTypeMystery
+	Food
+	Elixir
+	Scroll
 	Weapon
+	Treasure
 )

--- a/src/internal/common/common.go
+++ b/src/internal/common/common.go
@@ -19,5 +19,4 @@ const (
 	Elixir
 	Scroll
 	Weapon
-	Treasure
 )

--- a/src/internal/model/world/field_renderer.go
+++ b/src/internal/model/world/field_renderer.go
@@ -131,13 +131,13 @@ func (r *DefaultFieldRenderer) renderItems(
 		}
 
 		// Type switch для определения типа предмета
-		switch v := item.(type) {
+		switch item.(type) {
 		case *items.Food:
-			field[pt.Y][pt.X] = convertFoodToEntityType(v.Type)
+			field[pt.Y][pt.X] = common.Food
 		case *items.Elixir:
-			field[pt.Y][pt.X] = convertElixirToEntityType(v.Type)
+			field[pt.Y][pt.X] = common.Elixir
 		case *items.Scroll:
-			field[pt.Y][pt.X] = convertScrollToEntityType(v.Type)
+			field[pt.Y][pt.X] = common.Scroll
 		case *items.Weapon:
 			field[pt.Y][pt.X] = common.Weapon
 		case *items.Treasure:
@@ -177,59 +177,6 @@ func (r *DefaultFieldRenderer) isInBounds(x, y int, field [][]common.GameEntityT
 
 func (r *DefaultFieldRenderer) isInBoundsWH(x, y, width, height int) bool {
 	return x >= 0 && x < width && y >= 0 && y < height
-}
-
-// Вспомогательные функции для конвертации типов
-
-func convertFoodToEntityType(foodType items.FoodType) common.GameEntityType {
-	switch foodType {
-	case items.FoodTypePotatoes:
-		return common.FoodTypePotatoes
-	case items.FoodTypeBread:
-		return common.FoodTypeBread
-	case items.FoodTypeMeat:
-		return common.FoodTypeMeat
-	case items.FoodTypeMistery:
-		return common.FoodTypeMistery
-	case items.FoodTypeBeer:
-		return common.FoodTypeBeer
-	default:
-		return common.FoodTypeMistery
-	}
-}
-
-func convertElixirToEntityType(elixirType items.ElixirType) common.GameEntityType {
-	switch elixirType {
-	case items.ElixirTypeStrength:
-		return common.ElixirTypeStrength
-	case items.ElixirTypeAgility:
-		return common.ElixirTypeAgility
-	case items.ElixirTypeDwarfism:
-		return common.ElixirTypeDwarfism
-	case items.ElixirTypeGiantism:
-		return common.ElixirTypeGiantism
-	case items.ElixirTypeMystery:
-		return common.ElixirTypeMystery
-	default:
-		return common.ElixirTypeMystery
-	}
-}
-
-func convertScrollToEntityType(scrollType items.ScrollType) common.GameEntityType {
-	switch scrollType {
-	case items.ScrollTypeStrength:
-		return common.ScrollTypeStrength
-	case items.ScrollTypeAgility:
-		return common.ScrollTypeAgility
-	case items.ScrollTypeUltimate:
-		return common.ScrollTypeUltimate
-	case items.ScrollTypeMaxHealth:
-		return common.ScrollTypeMaxHealth
-	case items.ScrollTypeMystery:
-		return common.ScrollTypeMystery
-	default:
-		return common.ScrollTypeMystery
-	}
 }
 
 // Пример того, как можем из интерфейса определить конкретный тип, без доп. полей

--- a/src/internal/model/world/field_renderer_test.go
+++ b/src/internal/model/world/field_renderer_test.go
@@ -224,13 +224,13 @@ func TestDefaultFieldRenderer_RenderItems(t *testing.T) {
 	field := renderer.RenderField(10, 10, level)
 
 	// Проверяем предметы
-	if field[2][2] != common.FoodTypeBread {
+	if field[2][2] != common.Food {
 		t.Errorf("Expected bread at (2, 2), got %v", field[2][2])
 	}
-	if field[3][3] != common.ElixirTypeStrength {
+	if field[3][3] != common.Elixir {
 		t.Errorf("Expected strength elixir at (3, 3), got %v", field[3][3])
 	}
-	if field[4][4] != common.ScrollTypeAgility {
+	if field[4][4] != common.Scroll {
 		t.Errorf("Expected agility scroll at (4, 4), got %v", field[4][4])
 	}
 	if field[5][5] != common.Weapon {
@@ -381,21 +381,6 @@ func TestConversionFunctions(t *testing.T) {
 		testFunc func() common.GameEntityType
 		expected common.GameEntityType
 	}{
-		{
-			name:     "FoodTypeBread converts correctly",
-			testFunc: func() common.GameEntityType { return convertFoodToEntityType(items.FoodTypeBread) },
-			expected: common.FoodTypeBread,
-		},
-		{
-			name:     "ElixirTypeStrength converts correctly",
-			testFunc: func() common.GameEntityType { return convertElixirToEntityType(items.ElixirTypeStrength) },
-			expected: common.ElixirTypeStrength,
-		},
-		{
-			name:     "ScrollTypeAgility converts correctly",
-			testFunc: func() common.GameEntityType { return convertScrollToEntityType(items.ScrollTypeAgility) },
-			expected: common.ScrollTypeAgility,
-		},
 		{
 			name:     "EnemyTypeZombie converts correctly",
 			testFunc: func() common.GameEntityType { return convertEnemyToEntityType(&entities.Zombie{}) },

--- a/src/internal/model/world/fog_of_war_test.go
+++ b/src/internal/model/world/fog_of_war_test.go
@@ -161,7 +161,7 @@ func TestApplyFogOfWar(t *testing.T) {
 		// Создаём простое поле 5x5
 		fullField := [][]common.GameEntityType{
 			{common.WorldTypeRoomFloor, common.WorldTypeRoomFloor, common.WorldTypeRoomFloor, common.WorldTypeRoomFloor, common.WorldTypeRoomFloor},
-			{common.WorldTypeRoomFloor, common.FoodTypeBread, common.WorldTypeRoomFloor, common.WorldTypeRoomFloor, common.WorldTypeRoomFloor},
+			{common.WorldTypeRoomFloor, common.Food, common.WorldTypeRoomFloor, common.WorldTypeRoomFloor, common.WorldTypeRoomFloor},
 			{common.WorldTypeRoomFloor, common.WorldTypeRoomFloor, common.EntityTypePlayer, common.WorldTypeRoomFloor, common.WorldTypeRoomFloor},
 			{common.WorldTypeRoomFloor, common.WorldTypeRoomFloor, common.WorldTypeRoomFloor, common.EntityTypeZombie, common.WorldTypeRoomFloor},
 			{common.WorldTypeRoomFloor, common.WorldTypeRoomFloor, common.WorldTypeRoomFloor, common.WorldTypeRoomFloor, common.WorldTypeRoomFloor},
@@ -179,7 +179,7 @@ func TestApplyFogOfWar(t *testing.T) {
 		}
 
 		// Еда в радиусе видимости должна быть видна
-		if result[1][1] != common.FoodTypeBread {
+		if result[1][1] != common.Food {
 			t.Errorf("Food within view radius not visible")
 		}
 
@@ -307,7 +307,7 @@ func TestIsStaticTile(t *testing.T) {
 		{"portal is static", common.WorldTypePortal, true},
 		{"player is not static", common.EntityTypePlayer, false},
 		{"enemy is not static", common.EntityTypeZombie, false},
-		{"food is not static", common.FoodTypeBread, false},
+		{"food is not static", common.Food, false},
 		{"weapon is not static", common.Weapon, false},
 	}
 

--- a/src/internal/view/cli/game.go
+++ b/src/internal/view/cli/game.go
@@ -493,14 +493,11 @@ func (g *Game) getCellAppearance(entityType common.GameEntityType) (rune, string
 		return SymbolOgre, ColorOgre, colorBlack
 	case common.EntityTypeSnakeMage:
 		return SymbolSnakeMage, ColorSnakeMage, colorBlack
-	case common.FoodTypePotatoes, common.FoodTypeBread, common.FoodTypeMeat,
-		common.FoodTypeMistery, common.FoodTypeBeer:
+	case common.Food:
 		return SymbolFood, ColorFood, colorBlack
-	case common.ElixirTypeStrength, common.ElixirTypeAgility, common.ElixirTypeDwarfism,
-		common.ElixirTypeGiantism, common.ElixirTypeMystery:
+	case common.Elixir:
 		return SymbolElixir, ColorElixir, colorBlack
-	case common.ScrollTypeStrength, common.ScrollTypeAgility, common.ScrollTypeUltimate,
-		common.ScrollTypeMaxHealth, common.ScrollTypeMystery:
+	case common.Scroll:
 		return SymbolScroll, ColorScroll, colorBlack
 	case common.Weapon:
 		return SymbolWeapon, ColorWeapon, colorBlack


### PR DESCRIPTION
В общем у нас же зомби, орки и прочие твари на карте обозначаются своими собственными символами. И когда мы думали писать игру с детальными смайликами, я представляла, что у items тоже будут индивидуальные символы, как у enemies. То есть хлеб - обозначаться хлебом; пиво -пивом; всякие зелья будут свой цвет в зависимости от типа иметь; то же самое со свитками, что они будут разноцветными книжечками валяться. Я представляла так сделать, чтобы, как и в случае с врагами, уже издалека визуально понимать, какого типа item валяется, Mystery ли или Agility, хлеб ли или пиво.

Но то как сейчас мне тоже очень нравится, что визуальное разделение лишь на "еда, свитки, эликсир, оружие" и что нет визуальной нагрузки лишней рябистостью, какая могла бы быть, если бы каждый компонент по особому обозначался. Так что я убрала лишнее из кода